### PR TITLE
Bug Fix - do not convert nil payloads to JSON when posting

### DIFF
--- a/lib/eventbrite_sdk.rb
+++ b/lib/eventbrite_sdk.rb
@@ -94,7 +94,14 @@ module EventbriteSDK
   def self.post(params)
     params[:headers] = { 'Content-Type' => 'application/json' }
     params[:method] = :post
-    params[:payload] = params[:payload].to_json
+
+    # Don't convert nil to json.
+    #
+    # BadRequest is raised when you publish an event because the body sent is
+    # "null" (invalid json) and the API rejects it.
+    if params[:payload]
+      params[:payload] = params[:payload].to_json
+    end
 
     request(params)
   end

--- a/spec/eventbrite_sdk_spec.rb
+++ b/spec/eventbrite_sdk_spec.rb
@@ -142,6 +142,28 @@ describe EventbriteSDK do
         end.to raise_error(described_class::Unauthorized)
       end
     end
+
+    context 'when payload is not specified' do
+      it 'does not get converted to JSON' do
+        token = 'token'
+        described_class.token = token
+        response = double(body: { something_happened: true }.to_json)
+
+        allow(RestClient::Request).to receive(:execute).and_return(response)
+
+        described_class.post(url: 'events/1/publish')
+
+        expect(RestClient::Request).to have_received(:execute).with(
+          headers: {
+            'Content-Type' => 'application/json',
+            'Authorization' => "Bearer #{token}"
+          },
+          method: :post,
+          url: "#{described_class::BASE}/events/1/publish/",
+          verify_ssl: true,
+        )
+      end
+    end
   end
 
   describe '.token=' do


### PR DESCRIPTION
For POST endpoints that take no payload (like event publishing) the payload was being set to the string "null". As a result BadRequest was being raised. The API reported that the payload was not valid JSON.

This fixes that. Don't convert the payload to JSON when it's not specified.

