### PR TITLE
Fixing bug with changes to timezone and not utc JUST sending TZ.

### DIFF
--- a/lib/eventbrite_sdk/version.rb
+++ b/lib/eventbrite_sdk/version.rb
@@ -1,5 +1,5 @@
 module EventbriteSDK
   # Major should always line up with the major point release of the public API
   # v3 => 3.x.x
-  VERSION = '3.0.3'.freeze
+  VERSION = '3.0.4'.freeze
 end

--- a/spec/eventbrite_sdk/event_spec.rb
+++ b/spec/eventbrite_sdk/event_spec.rb
@@ -58,6 +58,42 @@ module EventbriteSDK
     end
 
     describe '#changes' do
+      it 'still sends utc event if only tz changed' do
+        event = described_class.new(
+          'start' => {
+            'utc' => '2012-01-01', 'timezone' => 'America/Los_Angeles'
+          }
+        )
+
+        event.assign_attributes(
+          'start.timezone' => 'America/Chicago',
+          'start.utc' => '2012-01-01'
+        )
+
+        expect(event.changes).to match(
+          'start.utc' => ['2012-01-01', '2012-01-01'],
+          'start.timezone' => ['America/Los_Angeles', 'America/Chicago']
+        )
+      end
+
+      it 'still sends utc event if only TZ changed, order does not matter' do
+        event = described_class.new(
+          'start' => {
+            'utc' => '2012-01-01', 'timezone' => 'America/Los_Angeles'
+          }
+        )
+
+        event.assign_attributes(
+          'start.utc' => '2012-01-01',
+          'start.timezone' => 'America/Chicago'
+        )
+
+        expect(event.changes).to match(
+          'start.utc' => ['2012-01-01', '2012-01-01'],
+          'start.timezone' => ['America/Los_Angeles', 'America/Chicago']
+        )
+      end
+
       it 'auto dirties TZ when you touch an attribute that ends in "utc"' do
         event = described_class.new(
           'start' => {


### PR DESCRIPTION
Just sending a TZ change with the same utc in a rich datetime field would cause the payload to just send 'timezone'. This fixes that