### PR TITLE
Adding #sales_start_after support in TicketClass

### DIFF
--- a/lib/eventbrite_sdk/ticket_class.rb
+++ b/lib/eventbrite_sdk/ticket_class.rb
@@ -28,6 +28,7 @@ module EventbriteSDK
       string 'sales_channels'
       datetime 'sales_start'
       datetime 'sales_end'
+      string 'sales_start_after'
       integer 'minimum_quantity'
       integer 'maximum_quantity'
       boolean 'auto_hide'

--- a/lib/eventbrite_sdk/version.rb
+++ b/lib/eventbrite_sdk/version.rb
@@ -1,5 +1,5 @@
 module EventbriteSDK
   # Major should always line up with the major point release of the public API
   # v3 => 3.x.x
-  VERSION = '3.0.4'.freeze
+  VERSION = '3.0.5'.freeze
 end

--- a/spec/eventbrite_sdk/ticket_class_spec.rb
+++ b/spec/eventbrite_sdk/ticket_class_spec.rb
@@ -2,6 +2,30 @@ require 'spec_helper'
 
 module EventbriteSDK
   RSpec.describe TicketClass do
+    describe 'defined schema' do
+      it 'responds to all everything defined in the schema' do
+        expect(subject).to respond_to :name
+        expect(subject).to respond_to :description
+        expect(subject).to respond_to :quantity_total
+        expect(subject).to respond_to :cost
+        expect(subject).to respond_to :fee
+        expect(subject).to respond_to :tax
+        expect(subject).to respond_to :free
+        expect(subject).to respond_to :include_fee
+        expect(subject).to respond_to :split_fee
+        expect(subject).to respond_to :sales_channels
+        expect(subject).to respond_to :sales_start
+        expect(subject).to respond_to :sales_end
+        expect(subject).to respond_to :sales_start_after
+        expect(subject).to respond_to :minimum_quantity
+        expect(subject).to respond_to :maximum_quantity
+        expect(subject).to respond_to :auto_hide
+        expect(subject).to respond_to :hidden
+        expect(subject).to respond_to :order_confirmation_message
+        expect(subject).to respond_to :on_sale_status
+      end
+    end
+
     describe '.retrieve' do
       context 'when found' do
         it 'returns the new instance with the populated attributes' do


### PR DESCRIPTION
TicketClass didn't support `sales_start_after`, now it does.