### PR TITLE
Add ability to fetch attendees of a particular event

### DIFF
--- a/lib/eventbrite_sdk/event.rb
+++ b/lib/eventbrite_sdk/event.rb
@@ -17,6 +17,7 @@ module EventbriteSDK
     belongs_to :venue, object_class: 'Venue'
 
     has_many :orders, object_class: 'Order'
+    has_many :attendees, object_class: 'Attendee'
     has_many :ticket_classes, object_class: 'TicketClass'
 
     schema_definition do

--- a/spec/eventbrite_sdk/event_spec.rb
+++ b/spec/eventbrite_sdk/event_spec.rb
@@ -207,6 +207,33 @@ module EventbriteSDK
       end
     end
 
+    describe '#attendees' do
+      context 'when event is new' do
+        it 'instantiates a BlankResourceList' do
+          expect(subject.attendees).to be_an_instance_of(BlankResourceList)
+          expect(subject.attendees).to be_empty
+        end
+      end
+
+      context 'when event exists' do
+        it 'hydrates a list of Attendees' do
+          stub_get(
+            path: 'events/31337',
+            fixture: :event_read,
+            override: { 'id' => '31337' },
+          )
+          stub_get(path: 'events/31337/attendees/?page=1', fixture: :attendees_read)
+
+          event = described_class.retrieve(id: '31337')
+
+          event.attendees.retrieve
+
+          expect(event.attendees).to be_an_instance_of(ResourceList)
+          expect(event.attendees.first).to be_an_instance_of(Attendee)
+        end
+      end
+    end
+
     describe '#ticket_classes' do
       context 'when event is new' do
         it 'instantiates a BlankResourceList' do


### PR DESCRIPTION
There is already an endpoint in the API for fetching the attendees of a particular event, so adding it to the SDK is as simple as adding the association.

Added specs based on the orders association spec, also tested locally against a real event.