### PR TITLE
Fix Event::CANNOT_UNPUBLISH so it has the correct value

### DIFF
--- a/lib/eventbrite_sdk/event.rb
+++ b/lib/eventbrite_sdk/event.rb
@@ -1,6 +1,6 @@
 module EventbriteSDK
   class Event < Resource
-    ERROR_CANNOT_PUBLISH = 'CANNOT_UNPUBLISH'.freeze
+    ERROR_CANNOT_UNPUBLISH = 'CANNOT_UNPUBLISH'.freeze
     ERROR_ALREADY_PUBLISHED_OR_DELETED = 'ALREADY_PUBLISHED_OR_DELETED'.freeze
 
     # Defines event#cancel, event#publish, and event#unpublish

--- a/spec/eventbrite_sdk/event_spec.rb
+++ b/spec/eventbrite_sdk/event_spec.rb
@@ -6,6 +6,15 @@ module EventbriteSDK
       EventbriteSDK.token = 'token'
     end
 
+    describe 'errors' do
+      it 'exposes the correct error types as constants' do
+        expect(described_class::ERROR_CANNOT_UNPUBLISH).
+          to eq('CANNOT_UNPUBLISH')
+        expect(described_class::ERROR_ALREADY_PUBLISHED_OR_DELETED).
+          to eq('ALREADY_PUBLISHED_OR_DELETED')
+      end
+    end
+
     describe '.search' do
       context 'when found' do
         it 'returns a list of events' do


### PR DESCRIPTION
The constant Event::CANNOT_PUBLISH was named wrong. It's value was for the cannot unpublish error type, so this corrects it's name.