### PR TITLE
Added error type constants that are generally useful

### DIFF
--- a/lib/eventbrite_sdk.rb
+++ b/lib/eventbrite_sdk.rb
@@ -3,6 +3,7 @@ require 'set'
 require 'rest_client'
 
 require 'eventbrite_sdk/version'
+require 'eventbrite_sdk/error_types'
 require 'eventbrite_sdk/exceptions'
 require 'eventbrite_sdk/resource/operations/attribute_schema'
 require 'eventbrite_sdk/resource/operations/list'

--- a/lib/eventbrite_sdk/error_types.rb
+++ b/lib/eventbrite_sdk/error_types.rb
@@ -1,0 +1,19 @@
+module EventbriteSDK
+  # These are general error types given in API responses.
+  # See the defined resource for error types that are unique to that resource.
+
+  # The resource is already deleted
+  ERROR_ALREADY_DELETED = 'ALREADY_DELETED'.freeze
+
+  # Paginated query had an invalid page, usually out of range
+  ERROR_BAD_PAGE = 'BAD_PAGE'.freeze
+
+  # Token was provided, but invalid
+  ERROR_BAD_TOKEN = 'INVALID_AUTH'.freeze
+
+  # The requested endpoint or resource does not exist
+  ERROR_NOT_FOUND = 'NOT_FOUND'.freeze
+
+  # No token was provided for an endpoint that requires authentication
+  ERROR_TOKEN_REQUIRED = 'NO_AUTH'.freeze
+end

--- a/spec/eventbrite_sdk_spec.rb
+++ b/spec/eventbrite_sdk_spec.rb
@@ -11,6 +11,14 @@ describe EventbriteSDK do
     expect(described_class::VERSION).not_to be nil
   end
 
+  it 'exposes general use error constants with correct values' do
+    expect(described_class::ERROR_ALREADY_DELETED).to eq('ALREADY_DELETED')
+    expect(described_class::ERROR_BAD_PAGE).to eq('BAD_PAGE')
+    expect(described_class::ERROR_BAD_TOKEN).to eq('INVALID_AUTH')
+    expect(described_class::ERROR_NOT_FOUND).to eq('NOT_FOUND')
+    expect(described_class::ERROR_TOKEN_REQUIRED).to eq('NO_AUTH')
+  end
+
   describe '::BASE' do
     it 'returns uri with MAJOR version after the `v`' do
       major = described_class::VERSION.split('.').first


### PR DESCRIPTION
This documents and adds the common error types that the endpoints return in the response when an API exception is raised.

```ruby
begin
  EventbriteSDK::Event.retrieve(id: 123)
rescue => ex
  p ex.parsed_error['error']
end

EventbriteSDK::ERROR_TOKEN_REQUIRED == ex.parsed_error['error']
# true
```

```ruby
begin
  EventbriteSDK.token = 'bad_token'
  EventbriteSDK::Event.retrieve(id: 123)
rescue => ex
  p ex.parsed_error['error']
end

EventbriteSDK::ERROR_BAD_TOKEN == ex.parsed_error['error']
# true
```


```ruby
begin
  EventbriteSDK.token = 'good_token'
  EventbriteSDK::Event.retrieve(id: 123)
rescue => ex
  p ex.parsed_error['error']
end

EventbriteSDK::ERROR_NOT_FOUND == ex.parsed_error['error']
# true
```