### PR TITLE
Enable ResourceList#retrieve with custom query params

### DIFF
--- a/lib/eventbrite_sdk/resource_list.rb
+++ b/lib/eventbrite_sdk/resource_list.rb
@@ -20,11 +20,9 @@ module EventbriteSDK
       @url_base = url_base
     end
 
-    def retrieve
-      response = load_response
-
-      @objects = (response[key.to_s] || []).map { |raw| object_class.new(raw) }
-      @pagination = response['pagination']
+    def retrieve(query: {})
+      @query.merge!(query)
+      load_response
 
       self
     end
@@ -72,7 +70,13 @@ module EventbriteSDK
     end
 
     def load_response
-      request.get(url: url_base, query: query.merge(page: page_number))
+      response = request.get(
+        url: url_base,
+        query: query.merge(page: page_number)
+      )
+
+      @objects = (response[key.to_s] || []).map { |raw| object_class.new(raw) }
+      @pagination = response['pagination']
     end
 
     attr_reader :expansion,

--- a/spec/eventbrite_sdk/resource_list_spec.rb
+++ b/spec/eventbrite_sdk/resource_list_spec.rb
@@ -117,6 +117,69 @@ module EventbriteSDK
           expect(list).to be_empty
         end
       end
+
+      context 'when :query is given' do
+        it 'merges the given values with what was given during instantiation' do
+          request = double('Request', get: {})
+          list = described_class.new(
+            query: { test: 'foo' },
+            request: request,
+            url_base: 'fart'
+          )
+
+          list.retrieve(query: { sun: 'glasses' })
+
+          expect(request).to have_received(:get).with(
+            url: 'fart',
+            query: {
+              test: 'foo',
+              page: 1,
+              sun: 'glasses'
+            }
+          )
+        end
+
+        context 'and #next_page is called after the initial custom query' do
+          it 'requests the next page with the custom :query values' do
+            request = double(
+              'Request',
+              get: {
+                'pagination' => {
+                  'page_number' => 1,
+                  'page_count' => 2
+                }
+              }
+            )
+            list = described_class.new(
+              query: { test: 'foo' },
+              request: request,
+              url_base: 'fart'
+            )
+
+            list.retrieve(query: { sun: 'glasses' })
+
+            expect(request).to have_received(:get).with(
+              url: 'fart',
+              query: {
+                test: 'foo',
+                page: 1,
+                sun: 'glasses'
+              }
+            )
+
+            list.next_page
+
+            expect(request).to have_received(:get).with(
+              url: 'fart',
+              query: {
+                test: 'foo',
+                page: 2,
+                sun: 'glasses'
+              }
+            )
+          end
+        end
+      end
     end
 
     context 'pagination' do


### PR DESCRIPTION
**What?**
This enables passing query parameters to ResourceList#retrieve.

**Why?**
It will make querying endpoints for associations with more complex endpoints cleaner and simpler. It will also do the same for querying a direct endpoint with more complex parameters.

**Compatibility**
All functionality is backwards compatible (non-breaking) and supports the paginated instance methods.

**Example**
```ruby
list = EventbriteSDK::ResourceList.new(
  key: 'things',
  object_class: Thing,
  url_base: 'test/'
)
list.retrieve(query: { name: 'foo' })

found_things = Things.other_things.retrieve(query: { name: 'foo' })
```