### PR TITLE
Add query option to #list operation. Add #concat, #to_ary to ResourceList

### DIFF
--- a/lib/eventbrite_sdk/resource/operations/list.rb
+++ b/lib/eventbrite_sdk/resource/operations/list.rb
@@ -2,10 +2,11 @@ module EventbriteSDK
   class Resource
     module Operations
       module List
-        def list
+        def list(query: {})
           ResourceList.new(
             key: path.split('/').first,
             object_class: EventbriteSDK.const_get(name.split('::').last),
+            query: query,
             url_base: new.path.gsub(/\/\Z/, '')
           )
         end

--- a/lib/eventbrite_sdk/resource_list.rb
+++ b/lib/eventbrite_sdk/resource_list.rb
@@ -20,6 +20,10 @@ module EventbriteSDK
       @url_base = url_base
     end
 
+    def concat(other)
+      other.concat(to_ary)
+    end
+
     def retrieve(query: {})
       @query.merge!(query)
       load_response
@@ -47,6 +51,10 @@ module EventbriteSDK
 
     %w(object_count page_number page_size page_count).each do |method|
       define_method(method) { pagination[method] }
+    end
+
+    def to_ary
+      objects
     end
 
     def to_json(opts = {})

--- a/spec/eventbrite_sdk/resource/operations/list_spec.rb
+++ b/spec/eventbrite_sdk/resource/operations/list_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+module EventbriteSDK
+  class Resource
+    module Operations
+      RSpec.describe List do
+        describe '.list' do
+          it 'passes given query to new ResourceList instance' do
+            list = instance_double(ResourceList)
+            class MyResource
+              extend EventbriteSDK::Resource::Operations::List
+
+              def self.path
+                'object/object'
+              end
+
+              def path
+                self.class.path
+              end
+
+              def self.name
+                'a::Event'
+              end
+            end
+
+            allow(ResourceList).to receive(:new).and_return(list)
+
+            MyResource.list(query: { test: 'test' })
+
+            expect(ResourceList).to have_received(:new).with(
+              key: MyResource.path.split('/').first,
+              object_class: EventbriteSDK::Event,
+              query: { test: 'test' },
+              url_base: MyResource.path
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/eventbrite_sdk/resource_list_spec.rb
+++ b/spec/eventbrite_sdk/resource_list_spec.rb
@@ -9,6 +9,25 @@ module EventbriteSDK
       end
     end
 
+    describe '#concat' do
+      it 'calls given object#concat with self#to_ary' do
+        payload = { 'events' => [ { 'id' => '1' } ] }
+
+        request = double('Request', get: payload)
+
+        list = described_class.new(
+          url_base: 'url',
+          object_class: Event,
+          key: :events,
+          request: request
+        )
+
+        list.retrieve
+
+        expect(list.concat([1])).to eq([1] + list.to_ary)
+      end
+    end
+
     describe '#retrieve' do
       context 'when query is set on initialization' do
         it 'calls request with query' do


### PR DESCRIPTION
TL;DR Moving some shims over from our patched version of the SDK.

* `Resouce::Operations::List#list` now accepts an optional query argument
* `ResourceList#concat` added
* `ResourceList#to_ary` added 
