### PR TITLE
Updating BlankResourceList to match ResourceList API

### DIFF
--- a/lib/eventbrite_sdk/blank_resource_list.rb
+++ b/lib/eventbrite_sdk/blank_resource_list.rb
@@ -4,7 +4,7 @@ module EventbriteSDK
     extend Forwardable
     include Enumerable
 
-    def_delegators :@objects, :[], :each, :empty?
+    def_delegators :@objects, :[], :concat, :each, :empty?, :to_ary
 
     def initialize(key: nil)
       @key = key
@@ -17,6 +17,10 @@ module EventbriteSDK
       retrieve
     ).each do |method|
       define_method(method) { self }
+    end
+
+    def concat(other)
+      other.concat(to_ary)
     end
 
     def page(_num)

--- a/lib/eventbrite_sdk/version.rb
+++ b/lib/eventbrite_sdk/version.rb
@@ -1,5 +1,5 @@
 module EventbriteSDK
   # Major should always line up with the major point release of the public API
   # v3 => 3.x.x
-  VERSION = '3.0.9'.freeze
+  VERSION = '3.0.10'.freeze
 end

--- a/spec/eventbrite_sdk/blank_resource_list_spec.rb
+++ b/spec/eventbrite_sdk/blank_resource_list_spec.rb
@@ -4,6 +4,14 @@ module EventbriteSDK
   RSpec.describe BlankResourceList do
     subject { described_class.new(key: 'key') }
 
+    describe '#concat' do
+      it 'returns what was given' do
+        result = subject.concat([1])
+
+        expect(result).to eq [1]
+      end
+    end
+
     describe '#next_page' do
       it 'returns itself' do
         expect(subject.next_page).to eq(subject)


### PR DESCRIPTION
The way we do recursive calls was exploding with the new `concat` methods since they don't exist on `BlanksResourceList`. This fixes that