### PR TITLE
Fix ResourceList - Allow Page to be Defined in Custom Query

### DIFF
--- a/lib/eventbrite_sdk/resource_list.rb
+++ b/lib/eventbrite_sdk/resource_list.rb
@@ -80,7 +80,7 @@ module EventbriteSDK
     def load_response(api_token)
       response = request.get(
         url: url_base,
-        query: query.merge(page: page_number),
+        query: { page: page_number }.merge(query),
         api_token: api_token
       )
 

--- a/spec/eventbrite_sdk/resource_list_spec.rb
+++ b/spec/eventbrite_sdk/resource_list_spec.rb
@@ -149,13 +149,13 @@ module EventbriteSDK
           list = described_class.new(
             query: { test: 'foo' },
             request: request,
-            url_base: 'fart'
+            url_base: 'testbase'
           )
 
           list.retrieve(query: { sun: 'glasses' })
 
           expect(request).to have_received(:get).with(
-            url: 'fart',
+            url: 'testbase',
             query: {
               test: 'foo',
               page: 1,
@@ -163,6 +163,29 @@ module EventbriteSDK
             },
             api_token: nil
           )
+        end
+
+        context 'and :page is given in the query' do
+          it 'overrides the current page' do
+            request = double('Request', get: {})
+            list = described_class.new(
+              query: { test: 'foo' },
+              request: request,
+              url_base: 'testbase'
+            )
+
+            list.retrieve(query: { page: 100, sun: 'glasses' })
+
+            expect(request).to have_received(:get).with(
+              url: 'testbase',
+              query: {
+                test: 'foo',
+                page: 100,
+                sun: 'glasses'
+              },
+              api_token: nil
+            )
+          end
         end
 
         context 'and #next_page is called after the initial custom query' do
@@ -179,13 +202,13 @@ module EventbriteSDK
             list = described_class.new(
               query: { test: 'foo' },
               request: request,
-              url_base: 'fart'
+              url_base: 'testbase'
             )
 
             list.retrieve(query: { sun: 'glasses' })
 
             expect(request).to have_received(:get).with(
-              url: 'fart',
+              url: 'testbase',
               query: {
                 test: 'foo',
                 page: 1,
@@ -197,7 +220,7 @@ module EventbriteSDK
             list.next_page
 
             expect(request).to have_received(:get).with(
-              url: 'fart',
+              url: 'testbase',
               query: {
                 test: 'foo',
                 page: 2,


### PR DESCRIPTION
When `page` is defined in a resource list query, it should be used. Right now it's ignored.