### PR TITLE
Fixing issue with rich datetime fields in payload changesets

### DIFF
--- a/spec/eventbrite_sdk/event_spec.rb
+++ b/spec/eventbrite_sdk/event_spec.rb
@@ -118,7 +118,7 @@ module EventbriteSDK
         )
       end
 
-      it "does not auto override if you are actually changing tz" do
+      it 'does not auto override if you are actually changing tz' do
         event = described_class.new(
           'start' => {
             'utc' => '2012-01-01', 'timezone' => 'America/Los_Angeles'
@@ -134,6 +134,53 @@ module EventbriteSDK
           'start.utc' => ['2012-01-01', '9999-99-99'],
           'start.timezone' => ['America/Los_Angeles', 'America/Chicago']
         )
+      end
+
+      it 'does not change when given an existing utc value' do
+        same_date = '2012-01-01'
+        event = described_class.new(
+          'start' => {
+            'utc' => same_date,
+            'timezone' => 'America/Los_Angeles'
+          }
+        )
+
+        event.assign_attributes('start.utc' => same_date)
+
+        expect(event).not_to be_changed
+      end
+
+      it 'does not change when given existing timezone value' do
+        same_tz = 'America/Los_Angeles'
+        event = described_class.new(
+          'start' => {
+            'utc' => '2012-01-01',
+            'timezone' => same_tz
+          }
+        )
+
+        event.assign_attributes('start.timezone' => same_tz)
+
+        expect(event).not_to be_changed
+      end
+
+      it 'does not change when gevn existing tz/utc values' do
+        same_tz = 'America/Los_Angeles'
+        same_utc = '2012-01-01'
+
+        event = described_class.new(
+          'start' => {
+            'timezone' => same_tz,
+            'utc' => same_utc
+          }
+        )
+
+        event.assign_attributes(
+          'start.timezone' => same_tz,
+          'start.utc' => same_utc
+        )
+
+        expect(event).not_to be_changed
       end
     end
 

--- a/spec/eventbrite_sdk/resource/field_spec.rb
+++ b/spec/eventbrite_sdk/resource/field_spec.rb
@@ -23,44 +23,22 @@ module EventbriteSDK
 
       describe '#changes' do
         context 'when key given has a sibling' do
-          context 'and the sibling exists in given attrs' do
-            it 'does not add the sibling to returned changes' do
-              attrs = {
-                'exist' => {
-                  'timezone' => 'old value'
-                }
+          it 'adds the sibling to returned changes' do
+            attrs = {
+              'exist' => {
+                'utc' => 'old value',
+                'timezone' => 'dupe me'
               }
-              existing_changes = {
-                'exist.utc' => ['old', 'new']
-              }
-              changeset = described_class.new('exist.timezone', 'new value')
+            }
+            existing_changes = {}
+            changeset = described_class.new('exist.utc', 'new value')
 
-              changes = changeset.changes(attrs, existing_changes)
+            changes = changeset.changes(attrs, existing_changes)
 
-              expect(changes).to eq(
-                'exist.timezone' => ['old value', 'new value']
-              )
-            end
-          end
-
-          context 'and the sibling does not exist in given attrs' do
-            it 'adds the sibling to returned changes' do
-              attrs = {
-                'exist' => {
-                  'utc' => 'old value',
-                  'timezone' => 'dupe me'
-                }
-              }
-              existing_changes = {}
-              changeset = described_class.new('exist.utc', 'new value')
-
-              changes = changeset.changes(attrs, existing_changes)
-
-              expect(changes).to eq(
-                'exist.timezone' => ['dupe me', 'dupe me'],
-                'exist.utc' => ['old value', 'new value']
-              )
-            end
+            expect(changes).to eq(
+              'exist.timezone' => ['dupe me', 'dupe me'],
+              'exist.utc' => ['old value', 'new value']
+            )
           end
         end
 


### PR DESCRIPTION
The SDK would generate changesets on rich datetime fields even if you technically did not change the value. This is problematic for activity logging in our product and needlessly pushes to v3.

Provided tests explain what this patch solves.