### PR TITLE
Threading api_token through Resource#retrieve

### DIFF
--- a/lib/eventbrite_sdk/resource/operations/endpoint.rb
+++ b/lib/eventbrite_sdk/resource/operations/endpoint.rb
@@ -34,11 +34,10 @@ module EventbriteSDK
               path.gsub(":#{key}", value.to_s)
             end
 
-            if params[:expand]
-              query = { expand: [*params[:expand]].join(',') }
-            end
+            api_token = params.fetch(:api_token, nil)
+            query = params[:expand] && { expand: [*params[:expand]].join(',') }
 
-            new request.get(url: url_path, query: query)
+            new request.get(url: url_path, query: query, api_token: api_token)
           end
 
           # Define the url path for the resource. It also implicitly defines

--- a/spec/eventbrite_sdk/resource/operations/endpoint_spec.rb
+++ b/spec/eventbrite_sdk/resource/operations/endpoint_spec.rb
@@ -9,9 +9,11 @@ module EventbriteSDK
             payload = 'payload'
             request = double('Request', get: payload)
 
-            result = TestEndpoint.retrieve({ 'id' => 1 }, request)
+            result = TestEndpoint.retrieve({ id:  1, api_token: 'a' }, request)
 
-            expect(request).to have_received(:get).with(url: 'test/1', query: nil)
+            expect(request).
+              to have_received(:get).
+              with(url: 'test/1', query: nil, api_token: 'a')
             expect(result.payload).to eq(payload)
           end
 
@@ -25,7 +27,11 @@ module EventbriteSDK
 
                 expect(request).
                   to have_received(:get).
-                  with(url: 'test/1', query: { expand: 'events' })
+                  with(
+                    url: 'test/1',
+                    query: { expand: 'events' },
+                    api_token: nil
+                )
                 expect(result.payload).to eq(payload)
               end
             end
@@ -41,7 +47,11 @@ module EventbriteSDK
 
                 expect(request).
                   to have_received(:get).
-                  with(url: 'test/1', query: { expand: 'events,users' })
+                  with(
+                    url: 'test/1',
+                    query: { expand: 'events,users' },
+                    api_token: nil
+                )
                 expect(result.payload).to eq(payload)
               end
             end
@@ -57,7 +67,11 @@ module EventbriteSDK
 
                 expect(request).
                   to have_received(:get).
-                  with(url: 'test/1', query: { expand: 'events,users' })
+                  with(
+                    url: 'test/1',
+                    query: { expand: 'events,users' },
+                    api_token: nil
+                )
                 expect(result.payload).to eq(payload)
               end
             end


### PR DESCRIPTION
### What's new?
A resource can `#save` using an `api_token` param, but it can't `#retrieve` using one. 

This patch addresses that.