### PR TITLE
Adding optional :api_token passthrough to Resource.define_api_actions

### DIFF
--- a/lib/eventbrite_sdk/resource.rb
+++ b/lib/eventbrite_sdk/resource.rb
@@ -27,8 +27,8 @@ module EventbriteSDK
     #   !new? && EventbriteSDK.post(url: path('unpublish'))
     # end
     def self.define_api_actions(*actions)
-      req = lambda do |inst, postfix|
-        inst.instance_eval { !new? && EventbriteSDK.post(url: path(postfix)) }
+      req = lambda do |inst, postfix, opts|
+        inst.instance_eval { !new? && EventbriteSDK.post(opts.merge(url: path(postfix))) }
       end
 
       actions.each do |action|
@@ -38,7 +38,7 @@ module EventbriteSDK
           method_name = postfix_path = action
         end
 
-        define_method(method_name) { req.call(self, postfix_path) }
+        define_method(method_name) { |opts = {}| req.call(self, postfix_path, opts) }
       end
     end
 

--- a/spec/eventbrite_sdk/event_spec.rb
+++ b/spec/eventbrite_sdk/event_spec.rb
@@ -197,6 +197,18 @@ module EventbriteSDK
             url: 'events/1/cancel'
           )
         end
+
+        it 'when given :api_token it passes it through' do
+          event = described_class.new('id' => '1')
+          allow(EventbriteSDK).to receive(:post).and_return('bahleted')
+
+          result = event.cancel(api_token: 'api_token')
+
+          expect(result).to eq('bahleted')
+          expect(EventbriteSDK).to have_received(:post).with(
+            url: 'events/1/cancel', api_token: 'api_token'
+          )
+        end
       end
 
       context 'when id is absent' do


### PR DESCRIPTION
# What's new?
`EventbriteSDK::Resource.define_api_actions` did not allow an optional `:api_token`.

This fixes that