### PR TITLE
Remove byebug dev dependency

### DIFF
--- a/lib/eventbrite_sdk/resource/schema_definition.rb
+++ b/lib/eventbrite_sdk/resource/schema_definition.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 module EventbriteSDK
   class Resource
     class SchemaDefinition


### PR DESCRIPTION
I tried to deploy our system to our livesystem and got an error that one file tries to load byebug, which is not used (and also shouldnt be used in production).

If you really need it, please add is as dependency to the gemspec file?