### PR TITLE
Adding Webhook#list to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ order.delete(api_token: YOUR_REQUEST_TOKEN)
 If you forget to provide the api_token key and `EventbriteSDK.token` is set, the request
 will fall-back on the global token for the action called.
 
+# Shallow resource list endpoints
+
+Some paginated lists are available at the base of the resource url, webhooks and 
+categories for example. The resources that have this trait will include the `Operations::List` module
+
+``` ruby
+
+# Retrieving
+
+categories = EventbriteSDK::Category.list.page(1) #=> GET /v3/categories/?page=1
+webhooks = EventbriteSDK::Webhook.list.page(1) #=> GET /v3/webhooks/?page=1
+```
 
 ## Development
 

--- a/lib/eventbrite_sdk/version.rb
+++ b/lib/eventbrite_sdk/version.rb
@@ -1,5 +1,5 @@
 module EventbriteSDK
   # Major should always line up with the major point release of the public API
   # v3 => 3.x.x
-  VERSION = '3.1.6'.freeze
+  VERSION = '3.2.0'.freeze
 end

--- a/lib/eventbrite_sdk/webhook.rb
+++ b/lib/eventbrite_sdk/webhook.rb
@@ -1,5 +1,7 @@
 module EventbriteSDK
   class Webhook < Resource
+    extend Operations::List
+
     resource_path 'webhooks/:id'
 
     schema_definition do

--- a/spec/eventbrite_sdk/webhook_spec.rb
+++ b/spec/eventbrite_sdk/webhook_spec.rb
@@ -4,6 +4,19 @@ module EventbriteSDK
   RSpec.describe Webhook do
     before { EventbriteSDK.token = 'token' }
 
+    describe '.list' do
+      it 'returns a new ResouceList' do
+        stub_endpoint(
+          path: 'webhooks/?page=1',
+          body: :webhooks,
+        )
+
+        list = described_class.list.retrieve
+
+        expect(list).to be_an_instance_of(ResourceList)
+      end
+    end
+
     describe '.retrieve' do
       context 'when found' do
         it 'returns a new instance' do

--- a/spec/fixtures/webhooks.json
+++ b/spec/fixtures/webhooks.json
@@ -1,0 +1,22 @@
+{
+    "pagination": {
+        "object_count": 1,
+        "page_count": 1,
+        "page_number": 1,
+        "page_size": 50
+    },
+    "webhooks": [
+        {
+            "actions": [
+                "order.placed",
+                "order.refunded"
+            ],
+            "created": "2017-10-12T12:01:38Z",
+            "endpoint_url": "https://some.url/that/receives/the/webhook",
+            "event_id": null,
+            "id": "12345",
+            "resource_uri": "https://www.eventbriteapi.com/v3/webhooks/12345/",
+            "user_id": "00001111"
+        }
+    ]
+}


### PR DESCRIPTION
# Adding `Webhook#list`

Closes #31

### What's new?
* `Webhook` is now endowed with `Operations::List` functionality
* Documentation on how to use it
* Version bump to `3.2.0`
