### PR TITLE
Added continuation and has_more_items to ResourceList

### DIFF
--- a/lib/eventbrite_sdk/resource_list.rb
+++ b/lib/eventbrite_sdk/resource_list.rb
@@ -49,7 +49,14 @@ module EventbriteSDK
       page(pagination['page_number'] - 1, api_token: api_token)
     end
 
-    %w[object_count page_number page_size page_count].each do |method|
+    %w[
+      continuation
+      has_more_items
+      object_count
+      page_number
+      page_size
+      page_count
+    ].each do |method|
       define_method(method) { pagination[method] }
     end
 

--- a/spec/eventbrite_sdk/resource_list_spec.rb
+++ b/spec/eventbrite_sdk/resource_list_spec.rb
@@ -237,6 +237,8 @@ module EventbriteSDK
       it 'returns the value provided in the requests `pagination` payload' do
         pagination = {
           'pagination' => {
+            'continuation' => 'abc',
+            'has_more_items' => true,
             'object_count' => 13,
             'page_number' => 2,
             'page_size' => 50,
@@ -255,6 +257,8 @@ module EventbriteSDK
 
         list.retrieve
 
+        expect(list.continuation).to eq('abc')
+        expect(list.has_more_items).to eq(true)
         expect(list.object_count).to eq(13)
         expect(list.page_number).to eq(2)
         expect(list.page_size).to eq(50)


### PR DESCRIPTION
Some endpoints support continuated responses but there is no good way to access the data aside from checking internal state.

I exposed continuation and has_more_items so endpoints that support continuated responses will be usable.