### PR TITLE
Adding SDK support for continuations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ events = user.owned_events.page(1) => events = user.owned_events
 events.first => events[0]
 events.last => events[-1]
 
+# endpoints that support continuations: will be inferred from the current payload
+# you can tell if a paginated result set supports continuations by checking for a non-nil #continuation
+
+example.continuation #=> "dGhpcyBpcyBwYWdlIDE"
+
+# you can continue until the example returns nil, which means there are no more items
+example.continue
+
+# you can also provide a token if you choose to do so
+example.continue(continuation_token: 'my_token')
 ```
 # Construct endpoint paths:
 

--- a/lib/eventbrite_sdk/resource_list.rb
+++ b/lib/eventbrite_sdk/resource_list.rb
@@ -24,6 +24,17 @@ module EventbriteSDK
       other.concat(to_ary)
     end
 
+    def continue(continuation_token: nil, api_token: nil)
+      continuation_token ||= continuation
+
+      return unless continuation_token || has_more_items
+
+      retrieve(
+        api_token: api_token,
+        query: {continuation: continuation_token}
+      )
+    end
+
     def retrieve(query: {}, api_token: nil)
       @query.merge!(query)
       load_response(api_token)
@@ -32,21 +43,22 @@ module EventbriteSDK
     end
 
     def page(num, api_token: nil)
-      pagination['page_number'] = num
-
-      retrieve(api_token: api_token)
+      retrieve(
+        api_token: api_token,
+        query: { page: num },
+      )
     end
 
     def next_page(api_token: nil)
       return if page_number >= (page_count || 1)
 
-      page(pagination['page_number'] + 1, api_token: api_token)
+      page(page_number + 1, api_token: api_token)
     end
 
     def prev_page(api_token: nil)
       return if page_number <= 1
 
-      page(pagination['page_number'] - 1, api_token: api_token)
+      page(page_number - 1, api_token: api_token)
     end
 
     %w[
@@ -93,11 +105,7 @@ module EventbriteSDK
     end
 
     def load_response(api_token)
-      response = request.get(
-        url: url_base,
-        query: { page: page_number }.merge(query),
-        api_token: api_token
-      )
+      response = request.get(api_token: api_token, query: query.dup, url: url_base)
 
       @objects = (response[key.to_s] || []).map { |raw| object_class.new(raw) }
       @pagination = response['pagination']

--- a/spec/eventbrite_sdk/category_spec.rb
+++ b/spec/eventbrite_sdk/category_spec.rb
@@ -5,7 +5,7 @@ module EventbriteSDK
     describe '.list' do
       it 'returns a new ResouceList' do
         stub_endpoint(
-          path: 'categories/?page=1',
+          path: 'categories',
           body: :categories,
         )
 

--- a/spec/eventbrite_sdk/event_spec.rb
+++ b/spec/eventbrite_sdk/event_spec.rb
@@ -19,7 +19,7 @@ module EventbriteSDK
       context 'when found' do
         it 'returns a list of events' do
           stub_endpoint(
-            path: 'events/search/?user.id=123&page=1',
+            path: 'events/search/?user.id=123',
             body: :events,
           )
           events = described_class.search('user.id' => 123).retrieve
@@ -265,7 +265,7 @@ module EventbriteSDK
               override: { 'id' => '31337' }
             }
           )
-          stub_get(path: 'events/31337/orders/?page=1', fixture: :event_orders)
+          stub_get(path: 'events/31337/orders', fixture: :event_orders)
 
           event = described_class.retrieve(id: '31337')
 
@@ -294,7 +294,7 @@ module EventbriteSDK
               override: { 'id' => '31337' }
             }
           )
-          stub_get(path: 'events/31337/attendees/?page=1', fixture: :attendees_read)
+          stub_get(path: 'events/31337/attendees', fixture: :attendees_read)
 
           event = described_class.retrieve(id: '31337')
 
@@ -324,7 +324,7 @@ module EventbriteSDK
             }
           )
           stub_get(
-            path: 'events/31337/ticket_classes/?page=1',
+            path: 'events/31337/ticket_classes',
             fixture: :event_ticket_classes
           )
 

--- a/spec/eventbrite_sdk/lists/owned_event_orders_list_spec.rb
+++ b/spec/eventbrite_sdk/lists/owned_event_orders_list_spec.rb
@@ -15,9 +15,9 @@ module EventbriteSDK
             list.search('term').retrieve
 
             expect(request).to have_received(:get).with(
+              api_token: nil,
+              query: { search_term: 'term' },
               url: 'users/me/search_owned_event_orders',
-              query: { search_term: 'term', page: 1 },
-              api_token: nil
             )
           end
         end
@@ -33,9 +33,9 @@ module EventbriteSDK
             list.search(false).retrieve
 
             expect(request).to have_received(:get).with(
+              api_token: nil,
+              query: {},
               url: 'users/me/owned_event_orders',
-              query: { page: 1 },
-              api_token: nil
             )
           end
         end

--- a/spec/eventbrite_sdk/order_spec.rb
+++ b/spec/eventbrite_sdk/order_spec.rb
@@ -106,7 +106,7 @@ module EventbriteSDK
             body: :order_read,
           )
           stub_endpoint(
-            path: 'orders/12345/attendees/?page=1',
+            path: 'orders/12345/attendees',
             body: :attendees_read,
           )
 

--- a/spec/eventbrite_sdk/subcategory_spec.rb
+++ b/spec/eventbrite_sdk/subcategory_spec.rb
@@ -5,7 +5,7 @@ module EventbriteSDK
     describe '.list' do
       it 'returns a new ResouceList' do
         stub_endpoint(
-          path: 'subcategories/?page=1',
+          path: 'subcategories',
           body: :subcategories,
         )
 

--- a/spec/eventbrite_sdk/webhook_spec.rb
+++ b/spec/eventbrite_sdk/webhook_spec.rb
@@ -7,7 +7,7 @@ module EventbriteSDK
     describe '.list' do
       it 'returns a new ResouceList' do
         stub_endpoint(
-          path: 'webhooks/?page=1',
+          path: 'webhooks',
           body: :webhooks,
         )
 


### PR DESCRIPTION
# What's new?
- Support for continuations through `ResourceList#continue`
- Adds continuation documentation
- Removed auto appending of `?page=1` on initial requests of `ResourceList`s

Addresses community ask: https://github.com/eventbrite/eventbrite-sdk-ruby/pull/35#issuecomment-435191744