### PR TITLE
[MINOR] Add Discounts, Organization and its entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Gemfile.lock
 .byebug_history
 coverage/
 tmp/
+.ruby-version

--- a/eventbrite_sdk.gemspec
+++ b/eventbrite_sdk.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rest-client', '~> 2.0'
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'bundler', '>= 2.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.11'

--- a/lib/eventbrite_sdk.rb
+++ b/lib/eventbrite_sdk.rb
@@ -22,9 +22,12 @@ require 'eventbrite_sdk/lists/owned_event_orders_list'
 
 require 'eventbrite_sdk/attendee'
 require 'eventbrite_sdk/category'
+require 'eventbrite_sdk/discount'
+require 'eventbrite_sdk/discounts_list'
 require 'eventbrite_sdk/event'
 require 'eventbrite_sdk/media'
 require 'eventbrite_sdk/order'
+require 'eventbrite_sdk/organization'
 require 'eventbrite_sdk/organizer'
 require 'eventbrite_sdk/report'
 require 'eventbrite_sdk/subcategory'
@@ -33,6 +36,7 @@ require 'eventbrite_sdk/ticket_group'
 require 'eventbrite_sdk/user'
 require 'eventbrite_sdk/venue'
 require 'eventbrite_sdk/webhook'
+require 'eventbrite_sdk/organization_entities' # depends on Discount, Event, Venue
 
 module EventbriteSDK
   BASE = "https://www.eventbriteapi.com/v#{VERSION.split('.').first}".freeze

--- a/lib/eventbrite_sdk/discount.rb
+++ b/lib/eventbrite_sdk/discount.rb
@@ -1,0 +1,78 @@
+module EventbriteSDK
+  class Discount < Resource
+    ACCESS_HIDDEN_TICKETS = 'access'.freeze # unlock access to hidden tickets
+    ACCESS_HOLDS = 'hold'.freeze            # unlock access to HoldClasses (reserved seating)
+    PROTECTED_DISCOUNT = 'coded'.freeze     # unlock a discount
+    PUBLIC_DISCOUNT = 'public'.freeze       # a publicly available discount
+
+    TYPES = [
+      ACCESS_HIDDEN_TICKETS,
+      ACCESS_HOLDS,
+      PROTECTED_DISCOUNT,
+      PUBLIC_DISCOUNT
+    ].freeze
+
+    resource_path 'discounts/:id'
+
+    belongs_to :event, object_class: 'Event'
+    belongs_to :ticket_group, object_class: 'TicketGroup'
+
+    attributes_prefix 'discount'
+
+    schema_definition do
+      string 'amount_off'           # Fixed reduction amount as a decimal - "12.99".
+      string 'code'                 # required: Code used to activate discount.
+      string 'discount_type'        # required: Type of discount. (Valid choices are: access, hold, coded, or public)
+      string 'end_date'             # Allow use until this date.
+      integer 'end_date_relative'   # Allow use until this number of seconds before the event starts.
+      string 'event_id'             # ID of the event. Only used for single event discounts.
+      string 'hold_ids'             # IDs of holds this discount can unlock
+      string 'percent_off'          # Percentage reduction. Supports 2 digit decimal precision - "50" or "50.01".
+      integer 'quantity_available'  # Number of discount uses.
+      string 'start_date'           # Allow use from this date.
+      integer 'start_date_relative' # Allow use from this number of seconds before the event starts.
+      string 'ticket_group_id'      # ID of the ticket group
+      string 'ticket_ids'           # IDs of tickets to limit discount to
+    end
+
+
+    def access_hidden_tickets?
+      discount_type == ACCESS_HIDDEN_TICKETS
+    end
+
+    def access_holds?
+      discount_type == ACCESS_HOLDS
+    end
+
+    def discount?
+      protected_discount? || public_discount?
+    end
+
+    def protected_discount?
+      discount_type == PROTECTED_DISCOUNT
+    end
+
+    def public_discount?
+      discount_type == PUBLIC_DISCOUNT
+    end
+
+    #
+    # Ticket groups that are auto created for all tickets of an org can NOT be
+    # accessed through the API, even though the ticket_group_id is present.
+    #
+    # We expand ticket_group on all queries - so ticket_group_id exists
+    # for that group, and ticket_group is present with a nil value in the data.
+    # In that case, when you call Discount#ticket_group the resource would
+    # attempt to retrieve it... and the API would return a 404 response. Bad.
+    #
+    # You can't use Discount#ticket_group unless it's safe to do so.
+    # You have to check the attribute data to verify that calling #ticket_group
+    # will not try to retrieve a "forbidden" group and raise an exception
+    #
+    def ticket_group_accessible?
+      !ticket_group_id.nil? &&
+        attrs.respond_to?(:ticket_group) &&
+        !attrs['ticket_group'].nil?
+    end
+  end
+end

--- a/lib/eventbrite_sdk/discounts_list.rb
+++ b/lib/eventbrite_sdk/discounts_list.rb
@@ -1,0 +1,53 @@
+EventbriteSDK::Lists.module_eval do
+  class DiscountsList < EventbriteSDK::ResourceList
+    def_delegators :@objects, :index, :shift
+
+    #
+    # Params...
+    #   scope: The scope to search within...
+    #     "event"        - single event only
+    #     "multi_events" - multi event only
+    #     "user"         - any type associated to the user "All"
+    #
+    #   event_id: (Optional) - Only discounts for the given event.
+    #   expand:   (Optional) - What, if any attributes to expand.
+    #   term:     (Optional) - Search for discounts w/ code having the term.
+    #   type:     (Optional) - A single value, or an array with the following...
+    #     "access" - codes that unlock hidden tickets
+    #     "coded"  - codes that apply a discount
+    #     "public" - discounts without a code, publicly available
+    #     "hold"   - held reserved seats activated via code
+    #
+    def search(scope:, event_id: nil, expand: nil, term: nil, type: nil)
+      type = coerce_type(type) if ! type.nil?
+
+      define_query_params(
+        code_filter: term,
+        discount_scope: scope,
+        event_id: event_id,
+        expand: expand,
+        type: type
+      )
+
+      self
+    end
+
+    private
+
+    def coerce_type(value)
+      value = [value] unless value.respond_to?(:join)
+      value.join(',')
+    end
+
+    # TODO: define in resource list and update accordingly
+    def define_query_params(params)
+      params.each do |name, value|
+        if ! value.nil?
+          @query[name] = value
+        else
+          @query.delete(name)
+        end
+      end
+    end
+  end
+end

--- a/lib/eventbrite_sdk/organization.rb
+++ b/lib/eventbrite_sdk/organization.rb
@@ -1,0 +1,88 @@
+module EventbriteSDK
+  class Organization < Resource
+    ALL_DISCOUNTS = 'user',
+    SINGLE_EVENT_DISCOUNTS = 'event',
+    MULTI_EVENT_DISCOUNTS = 'multi_events',
+
+    # Event search "order_by" values
+    CREATED_NEWEST_FIRST = 'created_desc',
+    CREATED_OLDEST_FIRST = 'created_asc',
+    START_NEWEST_FIRST = 'start_desc',
+    START_OLDEST_FIRST = 'start_asc',
+
+    # Event search "status" values
+    # ALL will cause the search to return any of the following:
+    #   canceled
+    #   ended
+    #   finalized
+    #   incomplete
+    #   live
+    #   started
+    #   payout_issued
+    ALL = 'all',
+    CANCELED = 'canceled',
+    DRAFT = 'draft',
+    # ENDED will return any of the following:
+    #   ended
+    #   finalized
+    #   payout_issued
+    ENDED = 'ended',
+    LIVE = 'live',
+    STARTED = 'started'
+
+    resource_path 'organizations/:id'
+
+    has_many :discounts, object_class: 'OrgDiscount'
+    has_many :organizers, object_class: 'Organizer', key: :organizers
+    # Previously :owned_event_orders
+    has_many :orders, object_class: 'Order', key: :orders
+    # Previously :owned_events
+    has_many :events, object_class: 'OrgEvent', key: :events
+    has_many :ticket_classes, object_class: 'TicketClass'
+    has_many :ticket_groups, object_class: 'TicketGroup'
+    # Query for all events, ordered by start date in ascending order.
+    #
+    #   order_by: Change the order they are returned. Supports:
+    #     created_asc
+    #     created_desc
+    #     start_asc
+    #     start_desc
+    #
+    #   status: Status(es) of events you want. Supports single values or CSV:
+    #     all      - all available statuses. Includes:
+    #     canceled - only canceled.
+    #     draft    - only draft
+    #     ended    - all ended statuses. Includes:
+    #     live     - only live
+    #     started  - only started
+    #
+    def upcoming_events(order_by: self.class::START_OLDEST_FIRST,
+                        status: self.class::ALL)
+      EventbriteSDK::ResourceList.new(
+        url_base: "#{path}/events",
+        object_class: EventbriteSDK::Event,
+        key: 'events',
+        query: {
+          order_by: order_by,
+          status: status
+        }
+      )
+    end
+
+    def search_orders(query)
+      EventbriteSDK::ResourceList.new(
+        url_base: "#{path}/orders/search",
+        object_class: EventbriteSDK::Order,
+        key: :orders,
+        query: {
+          search_term: query
+        }
+      )
+    end
+
+    # NOTE Shim to normalize API between a user/organization
+    def owned_events
+      events
+    end
+  end
+end

--- a/lib/eventbrite_sdk/organization_entities.rb
+++ b/lib/eventbrite_sdk/organization_entities.rb
@@ -1,0 +1,16 @@
+class EventbriteSDK::OrgDiscount < EventbriteSDK::Discount
+  resource_path create: 'organizations/:organization_id/discounts',
+                update: 'discounts/:id'
+end
+
+class EventbriteSDK::OrgVenue < EventbriteSDK::Venue
+  resource_path create: 'organizations/:organization_id/venues',
+                update: 'venues/:id'
+end
+
+class EventbriteSDK::OrgEvent < EventbriteSDK::Event
+  resource_path create: 'organizations/:organization_id/events',
+                update: 'events/:id'
+
+  belongs_to :venue, object_class: 'OrgVenue'
+end

--- a/lib/eventbrite_sdk/version.rb
+++ b/lib/eventbrite_sdk/version.rb
@@ -1,5 +1,5 @@
 module EventbriteSDK
   # Major should always line up with the major point release of the public API
   # v3 => 3.x.x
-  VERSION = '3.4.0'.freeze
+  VERSION = '3.5.0'.freeze
 end

--- a/spec/eventbrite_sdk/discount_spec.rb
+++ b/spec/eventbrite_sdk/discount_spec.rb
@@ -1,0 +1,218 @@
+require 'spec_helper'
+
+module EventbriteSDK
+  RSpec.describe Discount do
+    it 'responds to defined schema' do
+      expect(subject).to respond_to(:amount_off)
+      expect(subject).to respond_to(:code)
+      expect(subject).to respond_to(:discount_type)
+      expect(subject).to respond_to(:end_date)
+      expect(subject).to respond_to(:end_date_relative)
+      expect(subject).to respond_to(:event_id)
+      expect(subject).to respond_to(:hold_ids)
+      expect(subject).to respond_to(:id)
+      expect(subject).to respond_to(:percent_off)
+      expect(subject).to respond_to(:quantity_available)
+      expect(subject).to respond_to(:start_date)
+      expect(subject).to respond_to(:start_date_relative)
+      expect(subject).to respond_to(:ticket_group_id)
+      expect(subject).to respond_to(:ticket_ids)
+    end
+
+    describe '#access_hidden_tickets?' do
+      context 'when discount_type is ACCESS_HIDDEN_TICKETS' do
+        it 'returns true' do
+          subject.assign_attributes(
+            discount_type: described_class::ACCESS_HIDDEN_TICKETS
+          )
+          expect(subject).to be_access_hidden_tickets
+        end
+      end
+
+      context 'when discount_type is not ACCESS_HIDDEN_TICKETS' do
+        it 'returns false' do
+          subject.assign_attributes(discount_type: 'foo')
+          expect(subject).not_to be_access_hidden_tickets
+        end
+      end
+    end
+
+    describe '#access_holds?' do
+      context 'when discount_type is ACCESS_HOLDS' do
+        it 'returns true' do
+          subject.assign_attributes(
+            discount_type: described_class::ACCESS_HOLDS
+          )
+          expect(subject).to be_access_holds
+        end
+      end
+
+      context 'when discount_type is not ACCESS_HOLDS' do
+        it 'returns false' do
+          subject.assign_attributes(discount_type: 'foo')
+          expect(subject).not_to be_access_holds
+        end
+      end
+    end
+
+    describe '#delete' do
+      it 'makes a DELETE request with the given attributes to the correct URL and returns true' do
+        subject = described_class.new(id: 'abc123')
+        path = "discounts/#{subject.id}"
+
+        stub_delete(path: path)
+
+        result = subject.delete
+
+        expect(result).to eq(true)
+        expect(path).to have_received_request(:delete).with(body: nil)
+      end
+    end
+
+    describe '#event' do
+      it 'retrieves the event and returns it' do
+        stub_get(
+          path: 'events/abc',
+          body: { id: 'abc' }
+        )
+
+        subject.assign_attributes(event_id: 'abc')
+
+        expect(subject.event).to be_a(Event)
+        expect('events/abc').to have_received_request(:get)
+      end
+    end
+
+    describe '#protected_discount?' do
+      context 'when discount_type is PROTECTED_DISCOUNT' do
+        it 'returns true' do
+          subject.assign_attributes(
+            discount_type: described_class::PROTECTED_DISCOUNT
+          )
+          expect(subject).to be_protected_discount
+        end
+      end
+
+      context 'when discount_type is not PROTECTED_DISCOUNT' do
+        it 'returns false' do
+          subject.assign_attributes(discount_type: 'foo')
+          expect(subject).not_to be_protected_discount
+        end
+      end
+    end
+
+    describe '#public_discount?' do
+      context 'when discount_type is PUBLIC_DISCOUNT' do
+        it 'returns true' do
+          subject.assign_attributes(
+            discount_type: described_class::PUBLIC_DISCOUNT
+          )
+          expect(subject).to be_public_discount
+        end
+      end
+
+      context 'when discount_type is not PUBLIC_DISCOUNT' do
+        it 'returns false' do
+          subject.assign_attributes(discount_type: 'foo')
+          expect(subject).not_to be_public_discount
+        end
+      end
+    end
+
+    describe '#save' do
+      it 'posts the given attributes to the correct URL and returns true' do
+        attrs = {
+          amount_off: 999,
+          discount_type: described_class::PROTECTED_DISCOUNT
+        }
+        stub_post(
+          path: 'discounts',
+          body: { id: 'foo' }
+        )
+
+        subject.assign_attributes(attrs)
+        result = subject.save
+
+        expect(result).to eq(true)
+        expect('discounts').to have_received_request(:post).with(
+          body: { discount: attrs }
+        )
+      end
+
+      context 'when event_id is given' do
+        it 'also includes the event id in the request' do
+          attrs = {
+            amount_off: 999,
+            discount_type: described_class::PROTECTED_DISCOUNT,
+            event_id: 'event123'
+          }
+          stub_post(
+            path: 'discounts',
+            body: { id: 'foo' }
+          )
+
+          subject.assign_attributes(attrs)
+          result = subject.save
+
+          expect(result).to eq(true)
+          expect('discounts').to have_received_request(:post).with(
+            body: { discount: attrs }
+          )
+        end
+      end
+    end
+
+    describe '#ticket_group' do
+      it 'retrieves the ticket_group and returns it' do
+        stub_get(
+          path: 'ticket_groups/abc',
+          body: { id: 'abc' }
+        )
+
+        subject.assign_attributes(ticket_group_id: 'abc')
+
+        expect(subject.ticket_group).to be_a(TicketGroup)
+        expect('ticket_groups/abc').to have_received_request(:get)
+      end
+    end
+
+    describe '#ticket_group_accessible?' do
+      context 'when ticket_group_id is present' do
+        context 'and ticket_group is defined in the attributes' do
+          context 'and the value is not nil' do
+            it 'returns true' do
+              subject = described_class.new(
+                ticket_group: { id: 'abc123' },
+                ticket_group_id: 'abc123'
+              )
+
+              expect(subject).to be_ticket_group_accessible
+            end
+          end
+
+          context 'and the value is nil' do
+            it 'returns false' do
+              subject = described_class.new(
+                ticket_group: nil,
+                ticket_group_id: 'abc123'
+              )
+
+              expect(subject).not_to be_ticket_group_accessible
+            end
+          end
+        end
+
+        context 'and ticket_group is not defined in the attributes' do
+          it 'returns false' do
+            # Since ticket_group is not defined in the schema, but as a
+            # relationship, it is not going to be present in the attrs unless
+            # you give it.
+            subject = described_class.new(ticket_group_id: 'abc123')
+
+            expect(subject).not_to be_ticket_group_accessible
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/eventbrite_sdk/lists/discounts_list_spec.rb
+++ b/spec/eventbrite_sdk/lists/discounts_list_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+module EventbriteSDK
+  module Lists
+    RSpec.describe DiscountsList do
+      describe '#search' do
+        it 'defines the discount_scope param and returns itself' do
+          request = double(get: {})
+          subject = described_class.new(
+            key: 'discounts',
+            request: request,
+            url_base: 'discounts/'
+          )
+
+          subject.search(scope: 'minty').retrieve
+
+          expect(request).to have_received(:get).with(
+            url: 'discounts/',
+            query: {
+              discount_scope: 'minty',
+            },
+            api_token: nil
+          )
+        end
+
+        context 'when event_id is given' do
+          it 'also defines event_id' do
+            request = double(get: {})
+            subject = described_class.new(
+              key: 'discounts',
+              request: request,
+              url_base: 'discounts/'
+            )
+
+            subject.search(event_id: 12, scope: 'minty').retrieve
+
+            expect(request).to have_received(:get).with(
+              url: 'discounts/',
+              query: {
+                discount_scope: 'minty',
+                event_id: 12,
+              },
+              api_token: nil
+            )
+          end
+        end
+
+        context 'when term is given' do
+          it 'also defines code_filter' do
+            request = double(get: {})
+            subject = described_class.new(
+              key: 'discounts',
+              request: request,
+              url_base: 'discounts/'
+            )
+
+            subject.search(scope: 'minty', term: 'foo').retrieve
+
+            expect(request).to have_received(:get).with(
+              url: 'discounts/',
+              query: {
+                code_filter: 'foo',
+                discount_scope: 'minty',
+              },
+              api_token: nil
+            )
+          end
+        end
+
+        context 'when type is given' do
+          it 'also defines type' do
+            request = double(get: {})
+            subject = described_class.new(
+              key: 'discounts',
+              request: request,
+              url_base: 'discounts/'
+            )
+
+            subject.search(scope: 'minty', type: 'foo').retrieve
+
+            expect(request).to have_received(:get).with(
+              url: 'discounts/',
+              query: {
+                discount_scope: 'minty',
+                type: 'foo'
+              },
+              api_token: nil
+            )
+          end
+
+          context 'and the value is an array' do
+            it 'defines it as a simple CSV' do
+              request = double(get: {})
+              subject = described_class.new(
+                key: 'discounts',
+                request: request,
+                url_base: 'discounts/'
+              )
+
+              subject.search(scope: 'minty', type: %w(a b c d)).retrieve
+
+              expect(request).to have_received(:get).with(
+                url: 'discounts/',
+                query: {
+                  discount_scope: 'minty',
+                  type: 'a,b,c,d'
+                },
+                api_token: nil
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/eventbrite_sdk/organization_spec.rb
+++ b/spec/eventbrite_sdk/organization_spec.rb
@@ -1,0 +1,184 @@
+require 'spec_helper'
+
+module EventbriteSDK
+  RSpec.describe Organization do
+    describe '#discounts' do
+      it 'returns a ResourceList hydrated with the correct path' do
+        org = described_class.new(id: 'id')
+
+        stub_get(
+          path: "organizations/#{org.id}/discounts/?page=2",
+          body: {
+            discounts: [{ id: 'd' }]
+          }
+        )
+
+        list = org.discounts.page(2)
+
+        expect(list.first.id).to eq('d')
+      end
+    end
+
+    describe '#events' do
+      it 'returns a ResourceList hydrated with the correct path' do
+        org = described_class.new(id: 'id')
+
+        stub_get(
+          path: "organizations/#{org.id}/events/?page=1",
+          body: {
+            events: [{ id: 'e' }]
+          }
+        )
+
+        list = org.events.page(1)
+
+        expect(list.first.id).to eq('e')
+      end
+    end
+
+    describe '#orders' do
+      it 'returns a ResourceList hydrated with the correct path' do
+        org = described_class.new(id: 'id')
+
+        stub_get(
+          path: "organizations/#{org.id}/orders/?page=1",
+          body: {
+            orders: [{ id: 'o' }]
+          }
+        )
+
+        list = org.orders.page(1)
+
+        expect(list.first.id).to eq('o')
+      end
+    end
+
+    describe '#organizers' do
+      it 'returns a ResourceList hydrated with the correct path' do
+        org = described_class.new(id: 'id')
+
+        stub_get(
+          path: "organizations/#{org.id}/organizers/?page=1",
+          body: {
+            organizers: [{ id: 'o' }]
+          }
+        )
+
+        list = org.organizers.page(1)
+
+        expect(list.first.id).to eq('o')
+      end
+    end
+
+    describe '#owned_events' do
+      it 'returns the response for #events' do
+        org = described_class.new(id: 'id')
+
+        allow(org).to receive(:events).and_return('yay')
+
+        result = org.owned_events
+
+        expect(result).to eq('yay')
+      end
+    end
+
+    describe '#search_orders' do
+      it 'returns correctly instantiated ResourceList' do
+        subject = described_class.new(id: 'id')
+
+        allow(EventbriteSDK::ResourceList).
+          to receive(:new).and_call_original
+
+        subject.search_orders('whoa')
+
+        expect(EventbriteSDK::ResourceList).
+          to have_received(:new).
+          with({
+            url_base: 'organizations/id/orders/search',
+            object_class: EventbriteSDK::Order,
+            key: :orders,
+            query: {
+              search_term: 'whoa'
+            }
+          })
+      end
+    end
+
+    describe '#ticket_classes' do
+      it 'returns a ResourceList hydrated with the correct path' do
+        org = described_class.new(id: 'id')
+
+        stub_get(
+          path: "organizations/#{org.id}/ticket_classes/?page=1",
+          body: {
+            ticket_classes: [{ id: 't' }]
+          }
+        )
+
+        list = org.ticket_classes.page(1)
+
+        expect(list.first.id).to eq('t')
+      end
+    end
+
+    describe '#ticket_groups' do
+      it 'returns a ResourceList hydrated with the correct path' do
+        org = described_class.new(id: 'id')
+
+        stub_get(
+          path: "organizations/#{org.id}/ticket_groups/?page=1",
+          body: {
+            ticket_groups: [{ id: 't' }]
+          }
+        )
+
+        list = org.ticket_groups.page(1)
+
+        expect(list.first.id).to eq('t')
+      end
+    end
+
+    describe '#upcoming_events' do
+      it 'returns a ResourceList hydrated with the correct path' do
+        org = described_class.new(id: 'id')
+
+        stub_get(
+          path: "organizations/#{org.id}/events/?page=1&order_by=#{described_class::START_OLDEST_FIRST}&status=#{described_class::ALL}",
+          body: {
+            events: [{ id: 'e' }]
+          }
+        )
+
+        list = org.upcoming_events.page(1)
+
+        expect(list.first.id).to eq('e')
+      end
+
+      it 'accepts a custom order_by value' do
+        subject = described_class.new(id: 'id')
+
+        stub_get(
+          path: "organizations/#{subject.id}/events/?page=1&order_by=my_order&status=#{described_class::ALL}",
+          body: {
+            events: [{ id: 'e' }]
+          }
+        )
+
+        subject.upcoming_events(order_by: 'my_order').page(1)
+      end
+
+      it 'accepts a custom status value' do
+        subject = described_class.new(id: 'id')
+
+        stub_get(
+          path: "organizations/#{subject.id}/events/?page=1&order_by=#{described_class::START_OLDEST_FIRST}&status=my_status",
+          body: {
+            events: [{ id: 'e' }]
+          }
+        )
+
+        subject.upcoming_events(status: 'my_status').page(1)
+      end
+    end
+  end
+end

--- a/spec/support/endpoint_request_matchers.rb
+++ b/spec/support/endpoint_request_matchers.rb
@@ -30,11 +30,11 @@ RSpec::Matchers.define :have_received_request do |method|
     @webmock_matcher.matches?(WebMock)
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     @webmock_matcher.failure_message
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     @webmock_matcher.failure_message_when_negated
   end
 


### PR DESCRIPTION
Added the new entities to support organization API requests. This isn't complete but it get's us moving forward.

https://www.eventbrite.com/platform/api#/reference/event/list/list-events-by-organization
https://www.eventbrite.com/platform/api#/reference/venue/list/list-venues-by-organization
https://www.eventbrite.com/platform/api#/reference/discount/search-discounts-by-organization

## New Entities
- Discount
- DiscountsList
- Organization
- OrgDiscount
- OrgEvent
- OrgVenue

## Other Changes
- Added ruby version file for rbenv
- Bumped bundler dependency
- Updated our request matchers to remove use of deprecated methods