### PR TITLE
[MINOR] Add address type to resource schema definition

### DIFF
--- a/lib/eventbrite_sdk/resource/schema_definition.rb
+++ b/lib/eventbrite_sdk/resource/schema_definition.rb
@@ -9,6 +9,7 @@ module EventbriteSDK
       end
 
       %i[
+        address
         boolean
         currency
         datetime
@@ -56,6 +57,24 @@ module EventbriteSDK
       # The following fields are NO-OP expansions
       %i[boolean integer multipart string utc].each do |type|
         define_method("#{type}_expansion") { |val| }
+      end
+
+      def address_expansion(value)
+        generic_expansion(
+          %w[
+            address_1
+            address_2
+            city
+            country
+            latitude
+            localized_address_display
+            localized_area_display
+            longitude
+            postal_code
+            region
+          ],
+          value,
+        )
       end
 
       def currency_expansion(value)

--- a/lib/eventbrite_sdk/venue.rb
+++ b/lib/eventbrite_sdk/venue.rb
@@ -5,16 +5,7 @@ module EventbriteSDK
     attributes_prefix 'venue'
 
     schema_definition do
-      string 'address.address_1'
-      string 'address.address_2'
-      string 'address.city'
-      string 'address.country'
-      string 'address.latitude' # decimal, passed as string.
-      string 'address.localized_address_display'
-      string 'address.localized_area_display'
-      string 'address.longitude' # decimal, passed as string.
-      string 'address.postal_code'
-      string 'address.region'
+      address 'address'
       string 'age_restriction'
       string 'capacity'
       string 'latitude'

--- a/spec/eventbrite_sdk/resource/schema_definition_spec.rb
+++ b/spec/eventbrite_sdk/resource/schema_definition_spec.rb
@@ -16,6 +16,23 @@ module EventbriteSDK
       end
     end
 
+    describe '#address' do
+      it 'defines an address field with the given attributes' do
+        subject.address('foo')
+
+        expect(subject.type('foo.address_1')).to eq(:string)
+        expect(subject.type('foo.address_2')).to eq(:string)
+        expect(subject.type('foo.city')).to eq(:string)
+        expect(subject.type('foo.country')).to eq(:string)
+        expect(subject.type('foo.latitude')).to eq(:string)
+        expect(subject.type('foo.localized_address_display')).to eq(:string)
+        expect(subject.type('foo.localized_area_display')).to eq(:string)
+        expect(subject.type('foo.longitude')).to eq(:string)
+        expect(subject.type('foo.postal_code')).to eq(:string)
+        expect(subject.type('foo.region')).to eq(:string)
+      end
+    end
+
     describe '#type' do
       context 'when key exists' do
         it "returns it's type" do


### PR DESCRIPTION
This adds address as a supported schema type per the EB basic types.

https://www.eventbrite.com/platform/api#/introduction/basic-types/address

This also sets us up to support the many attendee addresses that the attendee endpoint supports.