### PR TITLE
Fix user.owned_events example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,8 @@ user = EventbriteSDK::User.retrieve(id: 'me')
 # or fetch a new user record using the Eventbrite user id
 user = EventbriteSDK::User.retrieve(id: 163054428874)
 
-# then fetch the user's organizations
-organizations = user.organizations
-
 # you can now fetch events per organization
-organization = organizations[0]
+organization = user.organizations.page(1).first
 events = organization.events.page(1)
 
 # not providing a page number will default to page one

--- a/README.md
+++ b/README.md
@@ -75,15 +75,20 @@ EventbriteSDK.token = "TOKEN"
 
 # one feature of the Eventbrite API is that you can pass in the string 'me' in place of a
 # user id and it will evaluate to the id of the user associated with the oauth token.
+user = EventbriteSDK::User.retrieve(id: 'me')
 
-# fetch a new user record using the Eventbrite user id
+# or fetch a new user record using the Eventbrite user id
 user = EventbriteSDK::User.retrieve(id: 163054428874)
 
-# get one page of your events
-events = user.owned_events.page(2)
+# then fetch the user's organizations
+organizations = user.organizations
+
+# you can now fetch events per organization
+organization = organizations[0]
+events = organization.events.page(1)
 
 # not providing a page number will default to page one
-events = user.owned_events.page(1) => events = user.owned_events
+events = organization.events.page(1) => events = organization.events
 
 # events is now an enumerable object that you can access using bracket notation or first/last
 events.first => events[0]
@@ -108,7 +113,8 @@ example.continue(continuation_token: 'my_token')
 # For example, to use the 'status' parameter seen here: https://www.eventbrite.com/developer/v3/endpoints/events/#ebapi-id78
 
 user = EventbriteSDK::User.retrieve(id: 163054428874)
-user.owned_events.retrieve(query: { status: 'live' })
+organization = user.organizations.first
+organization.events.retrieve(query: { status: 'live' })
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -200,4 +200,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/eventb
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/eventbrite_sdk/attendee.rb
+++ b/lib/eventbrite_sdk/attendee.rb
@@ -1,7 +1,8 @@
 module EventbriteSDK
   class Attendee < Resource
-    resource_path 'orders/:order_id/attendees/:id'
+    resource_path 'orders/:event_id/attendees/:id'
 
+    belongs_to :event, object_class: 'Event'
     belongs_to :order, object_class: 'Order'
 
     has_many :attendees, object_class: 'Attendee'

--- a/lib/eventbrite_sdk/attendee.rb
+++ b/lib/eventbrite_sdk/attendee.rb
@@ -1,6 +1,6 @@
 module EventbriteSDK
   class Attendee < Resource
-    resource_path 'orders/:event_id/attendees/:id'
+    resource_path 'events/:event_id/attendees/:id'
 
     belongs_to :event, object_class: 'Event'
     belongs_to :order, object_class: 'Order'

--- a/lib/eventbrite_sdk/event.rb
+++ b/lib/eventbrite_sdk/event.rb
@@ -23,6 +23,7 @@ module EventbriteSDK
 
     belongs_to :organizer, object_class: 'Organizer'
     belongs_to :venue, object_class: 'Venue'
+    belongs_to :organization, object_class: 'Organization'
 
     has_many :orders, object_class: 'Order'
     has_many :attendees, object_class: 'Attendee'

--- a/lib/eventbrite_sdk/user.rb
+++ b/lib/eventbrite_sdk/user.rb
@@ -5,6 +5,7 @@ module EventbriteSDK
     # NOTE: This name is pretty legacy. We should consider renaming
     # to "orders" to normalize things.
     has_many :owned_event_orders, object_class: 'Order', key: :orders
+    has_many :organizations, object_class: 'Organization', key: :organizations
 
     schema_definition do
       string 'name'

--- a/lib/eventbrite_sdk/webhook.rb
+++ b/lib/eventbrite_sdk/webhook.rb
@@ -2,7 +2,9 @@ module EventbriteSDK
   class Webhook < Resource
     extend Operations::List
 
-    resource_path 'webhooks/:id'
+    resource_path 'organizations/:organization_id/webhooks/:id'
+
+    belongs_to :organization, object_class: 'Organization'
 
     schema_definition do
       string 'endpoint_url'


### PR DESCRIPTION
The readme contains example of how to fetch `user.owned_events`, but this is recently deprecated and no longer returns event. This PR updates the docs to demo how to fetch events via organizations.